### PR TITLE
✨ feat(api): add api for delete PRP

### DIFF
--- a/src/api/routes/v1/individual.ts
+++ b/src/api/routes/v1/individual.ts
@@ -40,6 +40,7 @@ export default (app: Router) => {
     }),
   );
 
+  // TODO: isLoggedIn 미들웨어 만들어지면 모든 api에 isLoggedIn 추가하기
   // 개인 롤링페이퍼 조회
   route.get(
     "/papers/:paperId",
@@ -70,6 +71,25 @@ export default (app: Router) => {
   // 개인 롤링페이퍼 수정
 
   // 개인 롤링페이퍼 삭제
+  route.delete(
+    "/papers/:paperId", 
+    asyncHandler(
+      async (req: Request<PersonalRollingPaperInputDTO>, res: Response) => {
+        logger.debug(req.params);
+
+        // 비즈니스 로직을 처리할 service객체 받아오기
+        const personalServiceInstance = Container.get(PersonalService);
+
+        personalServiceInstance.deletePersonalRollingPaper(
+          req.params as PersonalRollingPaperInputDTO,
+        );
+
+        return res
+          .status(200)
+          .json({ result: "personal rolling paper deleted" });
+      },
+    ),
+  );
 
   // !GET, req 참고하세요!
   // 개인 롤링페이퍼 포스트 디테일 조회

--- a/src/services/individual.ts
+++ b/src/services/individual.ts
@@ -53,7 +53,7 @@ export default class PersonalService {
 
       const personalRollingPaper = await this.personalRollingPaperModel.findOne(
         {
-          where: { personal_rolling_paper_id: personalRollingPaperId },
+          where: { personal_rolling_paper_id: personalRollingPaperId, deleted_at: null },
         },
       );
 

--- a/src/services/individual.ts
+++ b/src/services/individual.ts
@@ -14,8 +14,6 @@ import {
   PersonalPostDTO,
 } from "@/interfaces/PersonalPost";
 
-import { Model } from "sequelize-typescript";
-
 @Service()
 export default class PersonalService {
   constructor(
@@ -104,7 +102,12 @@ export default class PersonalService {
     personalRollingPaperInputDTO: PersonalRollingPaperInputDTO,
   ) {
     try {
-      // TODO
+      const personalRollingPaperId = 
+        personalRollingPaperInputDTO.paperId;
+      
+      await this.personalRollingPaperModel.destroy({
+        where: { personal_rolling_paper_id: personalRollingPaperId },
+      });
     } catch (error) {
       this.logger.error(error);
       throw error;


### PR DESCRIPTION
# 개인 롤링페이퍼 삭제 기능 구현
<img width="1085" alt="스크린샷 2023-01-09 오후 11 12 36" src="https://user-images.githubusercontent.com/68101656/211327925-f9fd5efa-78d1-4b36-ad72-763dd563a92e.png">

## Sequelize의 테이블 옵션
`timestamps`: true이면 createdAt, updatedAt 컬럼을 추가되며, 데이터가 생성될 때와 수정될 때 시각이 자동으로 입력
`underscored`: 스네이크 표기법으로 바꿔준다.
`modelName`: 모델 이름
`tableName`: 실제 데이터베이스의 테이블 이름
`paranoid`: true이면 deletedAt 컬럼이 추가되며, **_데이터를 삭제할 때 완전히 지우지 않고_** 지운 시각이 기록된다. **_데이터 조회를 할때 deletedAt이 null인 인스턴스를 조회_** 한다.
데이터를 복원할 일이 있을 경우 paranoid를 true로 설정한다.
`charset` / `collate`: utf8로 설정해야 한글 입력 가능, utf8mb4는 이모티콘까지 입력 가능

## DB 결과
<img width="1303" alt="스크린샷 2023-01-09 오후 10 58 20" src="https://user-images.githubusercontent.com/68101656/211326406-464e839b-ff2c-4bf3-901b-2551df7752f3.png">
지운 시각만 기록되고 사실상 personal_rolling_paper_id는 아직 존재한다.
그러므로 이 id로 삭제수행을 계속 해도 딱히 에러가 나진 않는다.

## 수정
- 롤링페이퍼 조회 비즈니스 로직(service)
롤링페이퍼를 조회할 때 deleted_at == null 조건도 추가
<img width="1088" alt="스크린샷 2023-01-09 오후 11 33 32" src="https://user-images.githubusercontent.com/68101656/211334102-0b475367-b6c0-4fa3-bd5e-1d6f292b9562.png">

## 수정할 사항🔧
- 포스트 조회 로직 @j2woo 