### PR TITLE
✨ feat(api): add api for view list PRP

### DIFF
--- a/src/api/routes/v1/individual.ts
+++ b/src/api/routes/v1/individual.ts
@@ -98,7 +98,7 @@ export default (app: Router) => {
 
   // 개인 롤링페이퍼 목록 조회
   route.get(
-    "/papers/:userId/list",
+    "/papers/list/:userId",
     asyncHandler(async (req: Request<UserInputDTO>, res: Response) => {
         logger.debug(req.params);
 

--- a/src/api/routes/v1/individual.ts
+++ b/src/api/routes/v1/individual.ts
@@ -8,8 +8,12 @@ import {
   PersonalRollingPaperInputDTO,
   PersonalRollingPaperDTO,
 } from "@/interfaces/PersonalRollingPaper";
+import { UserInputDTO } from "@/interfaces/User";
+
+// ? routes에선 model 안쓰이는데 뺄까요??
 import PersonalPost from "@/models/personalPost";
 import PersonalRollingPaper from "@/models/personalRollingPaper";
+
 import PersonalService from "@/services/individual";
 import { Router, Request, Response, NextFunction } from "express";
 import { Container } from "typedi";
@@ -69,6 +73,7 @@ export default (app: Router) => {
   );
 
   // 개인 롤링페이퍼 수정
+  // TODO
 
   // 개인 롤링페이퍼 삭제
   route.delete(
@@ -89,6 +94,23 @@ export default (app: Router) => {
           .json({ result: "personal rolling paper deleted" });
       },
     ),
+  );
+
+  // 개인 롤링페이퍼 목록 조회
+  route.get(
+    "/papers/:userId/list",
+    asyncHandler(async (req: Request<UserInputDTO>, res: Response) => {
+        logger.debug(req.params);
+
+        // 비즈니스 로직을 처리할 service객체 받아오기
+        const personalServiceInstance = Container.get(PersonalService);
+
+        const { personalRollingPapers } = await personalServiceInstance.viewListPersonalRollingPaper(
+          req.params as UserInputDTO,
+        );
+
+        return res.status(200).json({ result: personalRollingPapers });
+      }),
   );
 
   // !GET, req 참고하세요!

--- a/src/services/individual.ts
+++ b/src/services/individual.ts
@@ -14,6 +14,10 @@ import {
   PersonalPostDTO,
 } from "@/interfaces/PersonalPost";
 
+import {
+  UserInputDTO,
+} from "@/interfaces/User";
+
 @Service()
 export default class PersonalService {
   constructor(
@@ -92,11 +96,8 @@ export default class PersonalService {
   }
 
   // 개인 롤링페이퍼 수정해주는 함수
-  // ? 아마 title, public_type만 수정할수있을듯
-  public async updatePersonalRollingPaper() {
-    // TODO
-  }
-
+  // TODO
+  
   // 개인 롤링페이퍼 삭제해주는 함수
   public async deletePersonalRollingPaper(
     personalRollingPaperInputDTO: PersonalRollingPaperInputDTO,
@@ -108,6 +109,28 @@ export default class PersonalService {
       await this.personalRollingPaperModel.destroy({
         where: { personal_rolling_paper_id: personalRollingPaperId },
       });
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  // 개인 롤링페이퍼 목록 조회해주는 함수
+  public async viewListPersonalRollingPaper(
+    userInputDTO: UserInputDTO,
+  ): Promise<{ personalRollingPapers: PersonalRollingPaper[] }> {
+    try {
+      const userId = userInputDTO.userId;
+
+      const personalRollingPapers = await this.personalRollingPaperModel.findAll({
+        where: { user_id: userId },
+      });
+
+      if(!personalRollingPapers) {
+        throw new Error("This user does not have any papers"); 
+      }
+
+      return { personalRollingPapers };
     } catch (error) {
       this.logger.error(error);
       throw error;


### PR DESCRIPTION
# 개인 롤링페이퍼 목록 조회
## 시행착오🧐
<img width="1272" alt="다른 라우터를 불러오는 현상" src="https://user-images.githubusercontent.com/68101656/211852342-1e4edf61-f996-468b-b4ed-8f443098eec3.png">

요청 url을 잘 적었는데도 **개인 롤링페이퍼 목록 조회**가 아닌 **개인 롤링페이퍼 조회** 라우터가 불러와지는것이다.

<img width="833" alt="목록 조회 api" src="https://user-images.githubusercontent.com/68101656/211852932-96ffd8b4-ff39-44ba-808a-9952a37bfca7.png">

알고보니 HTTP 메서드가 같고 URI구조가 같아 생긴 오류였다.
REST API에서 URI는 자원만을 의미한다.
userId인지 paperId인지는 사람이 이해하기위한 자원의 표현일뿐이고, 똑같은 자원이라는 것이다.

## api 수정 ‼️
`/api/v1/individual/papers/list/:userid`

## 결과
<img width="1268" alt="스크린샷 2023-01-12 오전 11 26 40" src="https://user-images.githubusercontent.com/68101656/211961416-3555bffd-618a-4fc0-adcd-0e3fceff583c.png">


> 위 내용 보완할 사항있으면 코멘트 달아주세요!💬
