### PR TITLE
✨feat(OAuth 2.0): add kakao login API

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/morgan": "^1.9.4",
     "@types/multer": "^1.4.7",
     "@types/node": "^18.11.18",
+    "@types/passport": "^1.0.11",
     "@types/supertest": "^2.0.12",
     "@types/validator": "^13.7.10",
     "@typescript-eslint/eslint-plugin": "^5.47.1",

--- a/src/api/middlewares/authMiddleware.ts
+++ b/src/api/middlewares/authMiddleware.ts
@@ -1,0 +1,78 @@
+import { verifyToken } from "@/utils/jwtUtil";
+
+export const verifyAccessToken = (req, res, next) => {
+  // 헤더에 토큰이 존재할 경우
+  if (req.headers.authorization) {
+    /**
+     * Http Header에 담긴 JWT: { "Authorization": "Bearer jwt-token" }
+     * 위와 같이 헤더에 담긴 access token을 가져오기 위해 문자열 분리
+     */
+    const token = req.headers.authorization.split("Bearer ")[1];
+
+    // 토큰 검증
+    const result = verifyToken(token);
+
+    /**
+     * 토큰 검증 성공 시,
+     * req에 값 저장 후 콜백 함수 호출
+     */
+    if (result.success) {
+      req.userId = result.userId;
+      req.email = result.email;
+      req.name = result.name;
+      next();
+    }
+
+    /**
+     * 토큰 검증 실패 시,
+     * 클라이언트에 에러 코드와 함께 에러 메시지 응답
+     */
+    if (!result.success) {
+      return res.status(401).json({
+        code: 401,
+        message: "Invalid Token",
+      });
+    }
+
+    /**
+     * 토큰 토큰 만료 시,
+     * 클라이언트에 에러 코드와 함께 에러 메시지 응답
+     */
+    if (result.message === "TokenExpiredError") {
+      return res.status(403).json({
+        code: 403,
+        message: "Token has expired",
+      });
+    }
+  }
+
+  // 헤더에 토큰이 존재하지 않는 경우
+  if (!req.headers.authorization) {
+    return res.status(404).json({
+      code: 404,
+      message: "Token does not exist",
+    });
+  }
+};
+
+export const isLoggedIn = (req, res, next) => {
+  if (req.isAuthenticated()) {
+    next();
+  } else {
+    res.status(403).send("로그인이 필요한 서비스입니다.");
+  }
+};
+
+export const isNotLoggedIn = (req, res, next) => {
+  if (!req.isAuthenticated()) {
+    next();
+  } else {
+    // 메시지를 생성하는 Query String(parameter)으로 사용할 것이기 때문에 Encoding을 해주어야 한다.
+    const message = encodeURIComponent("이미 로그인 상태입니다.");
+
+    // 이전 request 객체의 내용을 모두 삭제하고,
+    // 새로운 요청 흐름을 만드는 것으로 새로고침을 하면 결과 화면만 새로고침 된다.
+    res.redirect(`/?error=${message}`);
+    console.log(message);
+  }
+};

--- a/src/api/middlewares/authMiddleware.ts
+++ b/src/api/middlewares/authMiddleware.ts
@@ -54,25 +54,3 @@ export const verifyAccessToken = (req, res, next) => {
     });
   }
 };
-
-export const isLoggedIn = (req, res, next) => {
-  if (req.isAuthenticated()) {
-    next();
-  } else {
-    res.status(403).send("로그인이 필요한 서비스입니다.");
-  }
-};
-
-export const isNotLoggedIn = (req, res, next) => {
-  if (!req.isAuthenticated()) {
-    next();
-  } else {
-    // 메시지를 생성하는 Query String(parameter)으로 사용할 것이기 때문에 Encoding을 해주어야 한다.
-    const message = encodeURIComponent("이미 로그인 상태입니다.");
-
-    // 이전 request 객체의 내용을 모두 삭제하고,
-    // 새로운 요청 흐름을 만드는 것으로 새로고침을 하면 결과 화면만 새로고침 된다.
-    res.redirect(`/?error=${message}`);
-    console.log(message);
-  }
-};

--- a/src/api/middlewares/index.ts
+++ b/src/api/middlewares/index.ts
@@ -1,9 +1,7 @@
 import asyncHandler from "./asyncHandler";
-import { verifyAccessToken, isLoggedIn, isNotLoggedIn } from "./authMiddleware";
+import { verifyAccessToken } from "./authMiddleware";
 
 export default {
   asyncHandler,
   verifyAccessToken,
-  isLoggedIn,
-  isNotLoggedIn,
 };

--- a/src/api/middlewares/index.ts
+++ b/src/api/middlewares/index.ts
@@ -1,5 +1,9 @@
 import asyncHandler from "./asyncHandler";
+import { verifyAccessToken, isLoggedIn, isNotLoggedIn } from "./authMiddleware";
 
 export default {
   asyncHandler,
+  verifyAccessToken,
+  isLoggedIn,
+  isNotLoggedIn,
 };

--- a/src/api/routes/v1/auth.ts
+++ b/src/api/routes/v1/auth.ts
@@ -1,18 +1,26 @@
 import { Request, Response, Router, NextFunction } from "express";
+import passport from "passport";
 import { Container } from "typedi";
-import logger from "winston";
+import { Logger } from "winston";
 
 import asyncHandler from "@/api/middlewares/asyncHandler";
+import {
+  verifyAccessToken,
+  isLoggedIn,
+  isNotLoggedIn,
+} from "@/api/middlewares/authMiddleware";
 import { UserInputDTO } from "@/interfaces/User";
 import AuthService from "@/services/auth";
 
 const route = Router();
 
 export default (app: Router) => {
+  const logger: Logger = Container.get("logger");
   app.use("/auth", route);
 
   route.post(
     "/kakaotest",
+    verifyAccessToken,
     asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
       logger.debug(req.body);
       console.log("🚀 ~ file: auth.ts:17 ~ asyncHandler ~ body", req.body);
@@ -24,12 +32,51 @@ export default (app: Router) => {
     }),
   );
 
+  /**
+   ** 로그아웃 처리
+   *
+   * TODO: DB에서 refresh token 삭제
+   */
+  route.get(
+    "/logout",
+    verifyAccessToken,
+    asyncHandler(async (req: Request, res: Response) => {
+      res.cookie("refreshToken", "", {
+        maxAge: 0,
+      });
+      return res.status(200).json({
+        success: true,
+      });
+    }),
+  );
+
+  // 카카오 로그인 페이지
   route.get(
     "/kakao",
-    asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
-      logger.debug(req.body);
+    passport.authenticate("kakao", { session: false, failureRedirect: "/" }),
+  );
 
-      return res.status(200).json({ test: "good" });
+  // 카카오 로그인 리다이렉트 URI
+  route.get(
+    "/kakao/callback",
+    passport.authenticate("kakao", { session: false, failureRedirect: "/" }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const user = req.user;
+
+      const authServiceInstance = Container.get(AuthService);
+      const { token } = await authServiceInstance.createJwt(user);
+      logger.debug({ label: "JWT", message: token });
+
+      res.cookie("refreshToken", token.refreshToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        maxAge: 14 * 24 * 60 * 60 * 1000, // 14 day
+      });
+
+      return res
+        .status(200)
+        .json({ success: true, accessToken: token.accessToken });
     }),
   );
 };

--- a/src/api/routes/v1/auth.ts
+++ b/src/api/routes/v1/auth.ts
@@ -4,11 +4,7 @@ import { Container } from "typedi";
 import { Logger } from "winston";
 
 import asyncHandler from "@/api/middlewares/asyncHandler";
-import {
-  verifyAccessToken,
-  isLoggedIn,
-  isNotLoggedIn,
-} from "@/api/middlewares/authMiddleware";
+import { verifyAccessToken } from "@/api/middlewares/authMiddleware";
 import { UserInputDTO } from "@/interfaces/User";
 import AuthService from "@/services/auth";
 
@@ -63,9 +59,15 @@ export default (app: Router) => {
     asyncHandler(async (req: Request, res: Response) => {
       const user = req.user;
 
+      // Auth Service 로직 가져오기
       const authServiceInstance = Container.get(AuthService);
+
+      // JWT 발급(access token, refresh token)
       const { token } = await authServiceInstance.createJwt(user);
       logger.debug({ label: "JWT", message: token });
+
+      // DB에 refresh token 업데이트
+      await authServiceInstance.updateRefreshToken(user, token.refreshToken);
 
       res.cookie("refreshToken", token.refreshToken, {
         httpOnly: true,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -79,4 +79,11 @@ export default {
   api: {
     prefix: "/api",
   },
+
+  // JWT
+  jwtSecret: env.JWT_SECRET,
+
+  // 카카오 로그인
+  kakaoId: env.KAKAO_REST_API_KEY,
+  kakaoRedirectUri: env.KAKAO_REDIRECT_URI,
 };

--- a/src/interfaces/User.ts
+++ b/src/interfaces/User.ts
@@ -15,4 +15,11 @@ export interface User {
 
 export interface UserInputDTO {
   userId: string;
+  email: string;
+  name: string;
+}
+
+export interface TokenDTO {
+  accessToken: string;
+  refreshToken: string;
 }

--- a/src/loaders/logger.ts
+++ b/src/loaders/logger.ts
@@ -1,16 +1,35 @@
+import path from "path";
+
 import winston from "winston";
 
 import config from "@/config/config";
 
 const transports = [];
+const logFormat = winston.format.printf(
+  ({ timestamp, label, level, message, ...rest }) => {
+    let restString = JSON.stringify(rest, null, 2);
+    restString = restString === "{}" ? "" : restString;
+
+    // 날짜 [시스템이름] 로그레벨 메세지
+    return `${timestamp} [${
+      label || path.basename(process.mainModule.filename)
+    }] ${level}: ${message || ""} ${restString}`;
+  },
+);
+
 if (process.env.NODE_ENV !== "development") {
   transports.push(new winston.transports.Console());
 } else {
   transports.push(
     new winston.transports.Console({
       format: winston.format.combine(
+        winston.format.colorize(),
         winston.format.cli(),
+        winston.format.errors({ stack: true }),
+        winston.format.prettyPrint(),
         winston.format.splat(),
+        winston.format.json(),
+        logFormat,
       ),
     }),
   );
@@ -23,11 +42,14 @@ const LoggerInstance = winston.createLogger({
     winston.format.timestamp({
       format: "YYYY-MM-DD HH:mm:ss",
     }),
+    winston.format.colorize({ all: true }),
+    winston.format.cli(),
     winston.format.errors({ stack: true }),
+    winston.format.prettyPrint({ colorize: true }),
     winston.format.splat(),
     winston.format.json(),
   ),
-  transports,
+  transports: transports,
 });
 
 export default LoggerInstance;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -64,6 +64,10 @@ export default class User extends Model {
   @Column(DataType.ENUM(...Object.values(LoginType)))
   public login_type!: LoginType;
 
+  @AllowNull(true)
+  @Column(DataType.STRING(255))
+  public refresh_token!: string;
+
   /*
    * 관계에 대한 설정
    */

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -52,6 +52,7 @@ export default class AuthService {
     }
   }
 
+  // JWT(access token, refresh token) 발급 메서드
   public async createJwt(user): Promise<{ token: TokenDTO }> {
     try {
       const accessToken = createAccessToken(user);
@@ -66,13 +67,44 @@ export default class AuthService {
     }
   }
 
+  // DB에 refresh token 저장하는 메서드
+  public async updateRefreshToken(user, refreshToken) {
+    try {
+      const userRecord = await this.userModel.update(
+        {
+          refresh_token: refreshToken,
+        },
+        {
+          where: { user_id: user.user_id },
+        },
+      );
+
+      if (!userRecord) {
+        throw new Error("Unable to update refresh token");
+      }
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
   /**
-   * TODO 1: DB에 refresh token 저장하는 메서드 구현
-   *
    * TODO 2: 토큰 재발급 메서드 구현
    ** access token이 만료된 경우,
    ** refresh token을 이용해 access token 재발급
    ** 이후 refresh token도 재발급
    ** RTR(Refresh Token Rotation) -> refresh token은 일회성
    */
+  public async reCreateJwt(
+    accessToken,
+    refreshToken,
+  ): Promise<{ token: TokenDTO }> {
+    try {
+      const token = { accessToken, refreshToken };
+      return { token };
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -70,7 +70,7 @@ export default class AuthService {
   // DB에 refresh token 저장하는 메서드
   public async updateRefreshToken(user, refreshToken) {
     try {
-      const userRecord = await this.userModel.update(
+      const hasRefreshToken = await this.userModel.update(
         {
           refresh_token: refreshToken,
         },
@@ -79,7 +79,9 @@ export default class AuthService {
         },
       );
 
-      if (!userRecord) {
+      const canUpdateRefreshToken = hasRefreshToken[0];
+
+      if (!canUpdateRefreshToken) {
         throw new Error("Unable to update refresh token");
       }
     } catch (error) {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -55,9 +55,11 @@ export default class AuthService {
   // JWT(access token, refresh token) 발급 메서드
   public async createJwt(user): Promise<{ token: TokenDTO }> {
     try {
+      // access token 발급
       const accessToken = createAccessToken(user);
+      // refresh token 발급
       const refreshToken = createRefreshToken(user);
-
+      // token 변수에 access token과 refresh token을 객체로 담아 저장
       const token = { accessToken, refreshToken };
 
       return { token };
@@ -70,7 +72,8 @@ export default class AuthService {
   // DB에 refresh token 저장하는 메서드
   public async updateRefreshToken(user, refreshToken) {
     try {
-      const hasRefreshToken = await this.userModel.update(
+      // 매개변수로 받은 user의 id를 기준으로 refresh token을 저장
+      const updateRefreshToken = await this.userModel.update(
         {
           refresh_token: refreshToken,
         },
@@ -79,10 +82,44 @@ export default class AuthService {
         },
       );
 
-      const canUpdateRefreshToken = hasRefreshToken[0];
+      /*
+       * updateRefreshToken의 리턴값: [영향받은 행의 개수]
+       * update에 성공: [1]
+       * update에 실패: [0]
+       */
+      const canUpdateRefreshToken = updateRefreshToken[0];
 
+      // canUpdateRefreshToken의 값이 0(false)이면, 에러 발생
       if (!canUpdateRefreshToken) {
         throw new Error("Unable to update refresh token");
+      }
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  // DB에서 refresh token 삭제하는 메서드
+  public async deleteRefreshToken(userId) {
+    try {
+      // 매개변수로 받은 userId를 기준으로 refresh token을 삭제
+      const deleteRefreshToken = await this.userModel.update(
+        {
+          refresh_token: null,
+        },
+        { where: { user_id: userId } },
+      );
+
+      /*
+       * deleteRefreshToken의 리턴값: [영향받은 행의 개수]
+       * update에 성공: [1]
+       * update에 실패: [0]
+       */
+      const canDeleteRefreshToken = deleteRefreshToken[0];
+
+      // canDeleteRefreshToken의 값이 0(false)이면, 에러 발생
+      if (!canDeleteRefreshToken) {
+        throw new Error("Unable to delete refresh token");
       }
     } catch (error) {
       this.logger.error(error);

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -3,7 +3,8 @@ import { Model } from "sequelize-typescript";
 import { Service, Inject } from "typedi";
 
 import config from "@/config/config";
-import { User, UserInputDTO } from "@/interfaces/User";
+import { User, UserInputDTO, TokenDTO } from "@/interfaces/User";
+import { createAccessToken, createRefreshToken } from "@/utils/jwtUtil";
 
 @Service()
 export default class AuthService {
@@ -14,7 +15,7 @@ export default class AuthService {
 
   /**
    * 테스트 함수
-   * body로 요청 받은 유저 아이디(UUID)를 DB에서 찾은 후 JSON으로 전달해주는 함수수
+   * body로 요청 받은 유저 아이디(UUID)를 DB에서 찾은 후 JSON으로 전달해주는 함수
    */
   public async test(userInputDTO: UserInputDTO): Promise<{ user: User }> {
     try {
@@ -50,4 +51,28 @@ export default class AuthService {
       throw error;
     }
   }
+
+  public async createJwt(user): Promise<{ token: TokenDTO }> {
+    try {
+      const accessToken = createAccessToken(user);
+      const refreshToken = createRefreshToken(user);
+
+      const token = { accessToken, refreshToken };
+
+      return { token };
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  /**
+   * TODO 1: DB에 refresh token 저장하는 메서드 구현
+   *
+   * TODO 2: 토큰 재발급 메서드 구현
+   ** access token이 만료된 경우,
+   ** refresh token을 이용해 access token 재발급
+   ** 이후 refresh token도 재발급
+   ** RTR(Refresh Token Rotation) -> refresh token은 일회성
+   */
 }

--- a/src/services/passport/index.ts
+++ b/src/services/passport/index.ts
@@ -1,34 +1,5 @@
-import passport from "passport";
-
 import kakao from "./kakaoStrategy"; // 카카오 로그인
 
-import User from "@/models/user";
-
 export default () => {
-  /**
-   * Serialization: 객체를 직렬화하여 전송 가능한 형태로 만드는 것
-   * Deserialization: 직렬화된 파일 등을 역으로 직렬화하여 다시 객체 형태로 만드는 것
-   */
-  /*
-  type User = {
-    user_id?: string;
-  };
-
-  // 로그인 시 serializeUser 함수 실행
-  passport.serializeUser((user: User, done) => {
-    console.log("확인");
-    console.log(user.user_id);
-    done(null, user.user_id);
-  });
-
-  // 넘어온 id에 해당하는 데이터가 있으면, 데이터베이스에서 검색
-  passport.deserializeUser((user_id, done) => {
-    console.log(user_id);
-    User.findOne({ where: { user_id: user_id } })
-      .then((user) => done(null, user))
-      .catch((err) => done(err));
-  });
-  */
-
   kakao();
 };

--- a/src/services/passport/index.ts
+++ b/src/services/passport/index.ts
@@ -1,0 +1,34 @@
+import passport from "passport";
+
+import kakao from "./kakaoStrategy"; // 카카오 로그인
+
+import User from "@/models/user";
+
+export default () => {
+  /**
+   * Serialization: 객체를 직렬화하여 전송 가능한 형태로 만드는 것
+   * Deserialization: 직렬화된 파일 등을 역으로 직렬화하여 다시 객체 형태로 만드는 것
+   */
+  /*
+  type User = {
+    user_id?: string;
+  };
+
+  // 로그인 시 serializeUser 함수 실행
+  passport.serializeUser((user: User, done) => {
+    console.log("확인");
+    console.log(user.user_id);
+    done(null, user.user_id);
+  });
+
+  // 넘어온 id에 해당하는 데이터가 있으면, 데이터베이스에서 검색
+  passport.deserializeUser((user_id, done) => {
+    console.log(user_id);
+    User.findOne({ where: { user_id: user_id } })
+      .then((user) => done(null, user))
+      .catch((err) => done(err));
+  });
+  */
+
+  kakao();
+};

--- a/src/services/passport/kakaoStrategy.ts
+++ b/src/services/passport/kakaoStrategy.ts
@@ -1,0 +1,54 @@
+import passport from "passport";
+import KakaoStrategy from "passport-kakao";
+
+import config from "@/config/config";
+import Logger from "@/loaders/logger";
+import User from "@/models/user";
+
+export default () => {
+  passport.use(
+    new KakaoStrategy(
+      {
+        // 카카오 로그인 REST API 키
+        clientID: config.kakaoId,
+        // 카카오 로그인 Redirect URI 경로
+        callbackURL: config.kakaoRedirectUri,
+      },
+      async (accessToken, refreshToken, profile, done) => {
+        // 로그인 성공 시 정보 출력
+        Logger.verbose({ label: "KAKAO Profile", message: profile._json });
+        try {
+          /**
+           * 로그인 히스토리 조회
+           * 로그인 타입이 KAKAO이고, 카카오 아이디가 존재하는지 확인
+           */
+          const exUser = await User.findOne({
+            where: {
+              email: profile._json.kakao_account.email,
+              login_type: "KAKAO",
+            },
+          });
+
+          // 가입 여부 확인
+          if (exUser) {
+            // 로그인 인증 완료
+            done(null, exUser);
+          } else {
+            // 가입하지 않은 유저인 경우 회원가입 후 로그인
+            const newUser = await User.create({
+              email: profile._json.kakao_account.email,
+              name: profile.displayName,
+              password: null,
+              login_type: "KAKAO",
+            });
+            // 회원가입 후 로그인 인증 완료
+            done(null, newUser);
+          }
+        } catch (error) {
+          Logger.error(error);
+          done(error);
+        }
+      },
+    ),
+  );
+};

--- a/src/utils/jwtUtil.ts
+++ b/src/utils/jwtUtil.ts
@@ -1,0 +1,54 @@
+import jwt from "jsonwebtoken";
+
+import config from "@/config/config";
+
+const secret = config.jwtSecret;
+
+// access token 발급
+export const createAccessToken = (user) => {
+  const payload = {
+    userId: user.user_id,
+    email: user.email,
+    name: user.name,
+  };
+
+  const accessToken = jwt.sign({ payload }, config.jwtSecret, {
+    expiresIn: "30m",
+    issuer: "woocheonjae",
+  });
+
+  return accessToken;
+};
+
+// refresh token 발급
+export const createRefreshToken = (user) => {
+  const refreshToken = jwt.sign({}, config.jwtSecret, {
+    expiresIn: "14d",
+    issuer: "woocheonjae",
+  });
+
+  return refreshToken;
+};
+
+// access token 검증
+export const verifyToken = (token) => {
+  let decoded = null;
+  try {
+    // 토큰 확인
+    decoded = jwt.verify(token, secret);
+
+    return {
+      success: true,
+      userId: decoded.payload.userId,
+      email: decoded.payload.email,
+      name: decoded.payload.name,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      message: error.message,
+    };
+  }
+};
+
+// TODO: refresh token 검증 함수 구현

--- a/src/utils/jwtUtil.ts
+++ b/src/utils/jwtUtil.ts
@@ -31,11 +31,11 @@ export const createRefreshToken = (user) => {
 };
 
 // access token 검증
-export const verifyToken = (token) => {
+export const verifyAccessToken = (accessToken) => {
   let decoded = null;
   try {
     // 토큰 확인
-    decoded = jwt.verify(token, secret);
+    decoded = jwt.verify(accessToken, secret);
 
     return {
       success: true,
@@ -52,3 +52,6 @@ export const verifyToken = (token) => {
 };
 
 // TODO: refresh token 검증 함수 구현
+export const verifyRefreshToken = (token) => {
+  return null;
+};

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -1,16 +1,30 @@
 import session from "express-session";
 
+import IUser from "../../src/models/user";
+
 export = session;
 
-// process.d.ts
-// interface ProcessEnv extends Dict<string> {
-//   env: ProcessEnv;
-// }
+/**
+process.d.ts
+interface ProcessEnv extends Dict<string> {
+  env: ProcessEnv;
+}
 
-// global.d.ts
-// interface Dict<T> {
-//   [key: string]: T | undefined;
-// }
+global.d.ts
+interface Dict<T> {
+  [key: string]: T | undefined;
+}
+*/
+
+declare global {
+  namespace Express {
+    interface User {
+      user_id?: string;
+      email: string;
+      name: string;
+    }
+  }
+}
 
 // ?: 지금은 필요 없는 것 같음. 관련 에러 any 타입 선언으로 해결
 declare module "express-session" {

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,6 +873,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
 
+"@types/passport@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@types/passport/-/passport-1.0.11.tgz#d046b41e28b280f4e7994614fb976e9b449cb7c6"
+  integrity sha512-pz1cx9ptZvozyGKKKIPLcVDVHwae4hrH5d6g5J+DkMRRjR3cVETb4jMabhXAUbg3Ov7T22nFHEgaK2jj+5CBpw==
+  dependencies:
+    "@types/express" "*"
+
 "@types/prettier@^2.1.5":
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"


### PR DESCRIPTION
# 카카오톡 로그인 기능
## 구현 예정 기능
### TODO
#### ~1. DB에 refresh token 저장 메서드 구현~
#### ~2. 로그아웃 시 DB에서 refresh token 삭제~
#### 3. 토큰 재발급 메서드 구현
-  access token이 만료된 경우, refresh token을 이용해 access token 재발급
- 이후 refresh token도 재발급
   - RTR(Refresh Token Rotation)
      - refresh token은 일회성

## 카카오 로그인 인증 과정 [참고](https://inpa.tistory.com/entry/NODE-%F0%9F%93%9A-%EC%B9%B4%EC%B9%B4%EC%98%A4-%EB%A1%9C%EA%B7%B8%EC%9D%B8-Passport-%EA%B5%AC%ED%98%84)
> 참고 블로그와는 다르게 세션이 아닌 jwt를 이용하여 구현했습니다.
> `passport`가 로그인을 처리하는 과정을 참고해주시면 감사하겠습니다.

![image](https://user-images.githubusercontent.com/70932170/213847595-b0588d82-6e2a-4dbe-b2a6-ec331f7a5ce3.png)

# API
## 카카오 로그인 과정
### 1. `http://localhost:3030/api/v1/auth/kakao` 접속
![image](https://user-images.githubusercontent.com/70932170/213848004-db14784e-ffb4-4e4a-8459-8d7f53f99943.png)
### 2. 아래와 같이 카카오 로그인 페이지로 이동
![image](https://user-images.githubusercontent.com/70932170/213848017-960be067-4982-4f9b-a476-f73f7d7e65cf.png)
### 3. 카카오 로그인 후, `http://localhost:3030/api/v1/auth/kakao/Callback`으로 리다이렉트
![제목 없음](https://user-images.githubusercontent.com/70932170/213859939-2f20d4dc-65cb-4d87-a9c6-09ac01bac9f9.jpg)

### JWT 디코딩
![image](https://user-images.githubusercontent.com/70932170/213847666-663ed75b-deb4-4e93-a067-b7d014c4d625.png)

# 미들웨어
## Access Token 검증
### Access Token 검증 성공
![image](https://user-images.githubusercontent.com/70932170/213847789-fcba316e-c064-4aa5-a999-0b2c65dadebb.png)

### Access Token 검증 실패
![image](https://user-images.githubusercontent.com/70932170/213847824-364916b4-c932-495f-a3f0-6b5e4e7cfe93.png)

# 소셜 로그인 기능 참고

## JWT 저장 위치

#### 고민

- 구글이 2023년에 크롬에서 쿠키를 퇴출하고, 토픽스(플록의 논란으로 계획이 변경된 듯)라는 대체제를 도입하기로 함
- 이러한 상황을 고려하여 로컬 스토리지를 써볼까 했지만 XSS 취약점이 우려됨
- 쿠키가 사라지고 생기는 새로운 기술에 대한 공개가 되지도 않았고, 현 시점에서 쿠키가 사라질 것을 생각하고 대응하는 것은 무리라고 판단
- 쿠키의 취약점인 XSS, CSRF 공격은 쿠키 옵션(`httpOnly`, `secure`, `sameSite`)을 이용하여 안정성 확보

### Client

- Access Token
	- 메모리(`private` 변수)에 저장
- Refresh Token
	- Cookie
		- DB에 저장된 Refresh Token을 쿠키에 보관
		- 옵션
			- `httpOnly`
				- Script 접근 방어
			- `secure`
				- https 통신에서만 쿠키 사용 가능(패킷 감청 방어)
			- `sameSite=Lax`
				- `Strict` 모드
					- 동일한 도메인 범위에서만 쿠키 사용 가능
				- `Lax` 모드
					- 사용자가 페이지 이동이나 `form`을 통한 `GET` 요청 시에만 쿠키 사용 가능
	- ~~Local Storage~~
		- ~~DB에 저장된 Refresh Token의 index 값과 `user_id`를 조합하여 Hashing한 값을 저장~~

### Server

- Refresh Token
	- DB에 저장

## JWT 핸들링 과정

#### 1. Server

1. 로그인 시 `access token`과 `refresh token` 생성
2. `refresh token`을 DB에 저장
3. Client로 토큰 전달
	1. `access token`은 JSON 객체로 응답
	2. DB에 저장된 `refresh token`을 쿠키에 담아 `httpOnly`, `secure`, `sameSite=Lax` 옵션을 지정하여 응답

#### 2. Client

1. Server로부터 받은 `access token`은 메모리(`private` 변수)에 저장
2. 권한이 필요한 요청 시 `Authorization` Header에 `access token`을 담아 요청
3. `access token` 만료 혹은 페이지 이동으로 인해 토큰이 사라졌을 경우, Server로 `access token` 재발급 요청
	1. `access token` 재발급 요청 시, 쿠키에 `refresh token` 값을 담은 상태로 Server와 통신

#### 3. Server

1. `access token` 재발급 요청을 받을 경우, Client로부터 받은 `refresh token`을 확인 후 `access token`과 `refresh token`을 재생성한다.
	1. 이후 토큰 저장 과정은 앞서 기술한 것과 동일

# etc
## 1. 로그 파일 수정 (좀 더 손봐야 함)
- 로그 출력 시 객체 변수들이 `[object Object]`와 같이 포맷팅 된 채로 출력돼서 `logger.js`를 수정하였습니다.

---

close [BE/FEAT] 카카오톡 로그인 구현 #2